### PR TITLE
Change for usage paralect's fork of mailgun-js package

### DIFF
--- a/API.md
+++ b/API.md
@@ -19,7 +19,7 @@ Class which creates instances to sent emails.
     - `publicApiKey` - *(String)* - Your public Mailgun API KEY
     - `domain` - *(String)* - Your Mailgun Domain (Please note: domain field is `MY-DOMAIN-NAME.com`, not `https://api.mailgun.net/v3/MY-DOMAIN-NAME.com`)
     - `mute` - *(Boolena)* - Set to `true` if you wish to mute the console error logs in validateWebhook() function
-    - `proxy` - *(String)* - The proxy URI in format `http[s]://[auth@]host:port`. ex: `'http://proxy.example.com:8080'`
+    - `agent` - The [Agent](https://nodejs.org/docs/latest-v10.x/api/http.html#http_class_http_agent) to use - see [request](https://nodejs.org/docs/latest-v10.x/api/http.html#http_http_request_options_callback) options for the provided values. **Note** When providing an `agent` it must be able to handle the provided (or default) `protocol`.
     - `timeout` - *(Number)* - Request timeout in milliseconds
     - `host` - *(String)* - the mailgun host (default: `'api.mailgun.net'`)
     - `protocol` - *(String)* - the mailgun protocol (default: `'https:'`, possible values: `'http:'` or `'https:'`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paralect/email-service",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "author": "Paralect",
   "description": "Mailgun wrapper",
   "private": false,
@@ -17,8 +17,8 @@
   "license": "MIT",
   "dependencies": {
     "@paralect/common-logger": "0.1.10",
-    "handlebars": "4.7.4",
-    "mailgun-js": "0.22.0"
+    "@paralect/mailgun-js": "^0.24.0",
+    "handlebars": "4.7.4"
   },
   "devDependencies": {
     "all-contributors-cli": "6.14.1",

--- a/src/lib/mailer.js
+++ b/src/lib/mailer.js
@@ -1,4 +1,4 @@
-const mailgun = require('mailgun-js');
+const mailgun = require('@paralect/mailgun-js');
 const assert = require('assert');
 
 const logger = require('./logger');


### PR DESCRIPTION
Change library, because old mailgun-js is out of service, and it has some core problem (like using old proxy-agent lib, that influences some core node.js features and can cause random bugs with http/https protocol usage)